### PR TITLE
Experimental line width

### DIFF
--- a/LegacyDrawLine/src/Line.cpp
+++ b/LegacyDrawLine/src/Line.cpp
@@ -44,15 +44,20 @@ void Line::createPoints()
 
     int counter = 0;
     curr_pattern = m_pattern;
+    int pivot_point = floor(m_line_width / 2);
 
     glColor3f(m_line_color[0], m_line_color[1], m_line_color[2]);
 
     if (m_pStart[0] == m_pFinal[0] && m_pStart[1] == m_pFinal[1]) // a single point
     {
-        float ndc_x, ndc_y;
-        this->convertToNDC(m_pStart[0], m_pStart[1], &ndc_x, &ndc_y);
-        Set(ndc_x, ndc_y, 0.0f);
-        //std::cout << "case 0 (point)" << std::endl;
+        for (int j = 0; j < m_line_width; j++) {
+            for (int k = 0; k < m_line_width; k++) {
+                float ndc_x, ndc_y;
+                this->convertToNDC(m_pStart[0] + k - pivot_point, m_pStart[1] + j - pivot_point, &ndc_x, &ndc_y);
+                Set(ndc_x, ndc_y, 0.0f);
+                //std::cout << "case 0 (point)" << std::endl;
+            }
+        }
     }
     else if (m_pStart[1] == m_pFinal[1]) // horizontal line
     {
@@ -69,7 +74,7 @@ void Line::createPoints()
 
                 for (int j = 0; j < m_line_width; j++)
                 {
-                    this->convertToNDC(x, yvalue + j, &ndc_x, &ndc_y);
+                    this->convertToNDC(x, yvalue + j - pivot_point, &ndc_x, &ndc_y);
                     Set(ndc_x, ndc_y, ndc_z);
                 }
                 x++;
@@ -99,7 +104,7 @@ void Line::createPoints()
 
                 for (int j = 0; j < m_line_width; j++)
                 {
-                    this->convertToNDC(x, yvalue + j, &ndc_x, &ndc_y);
+                    this->convertToNDC(x, yvalue + j - pivot_point, &ndc_x, &ndc_y);
                     Set(ndc_x, ndc_y, ndc_z);
                 }
                 x++;
@@ -133,7 +138,7 @@ void Line::createPoints()
 
                 for (int j = 0; j < m_line_width; j++)
                 {
-                    this->convertToNDC(xvalue + j, y, &ndc_x, &ndc_y);
+                    this->convertToNDC(xvalue + j - pivot_point, y, &ndc_x, &ndc_y);
                     Set(ndc_x, ndc_y, ndc_z);
                 }
                 y++;
@@ -163,7 +168,7 @@ void Line::createPoints()
 
                 for (int j = 0; j < m_line_width; j++)
                 {
-                    this->convertToNDC(xvalue + j, y, &ndc_x, &ndc_y);
+                    this->convertToNDC(xvalue + j - pivot_point, y, &ndc_x, &ndc_y);
                     Set(ndc_x, ndc_y, ndc_z);
                 }
                 y++;
@@ -201,7 +206,7 @@ void Line::createPoints()
 
                     for (int j = 0; j < m_line_width; j++)
                     {
-                        this->convertToNDC(x, y + j, &ndc_x, &ndc_y);
+                        this->convertToNDC(x, y + j - pivot_point, &ndc_x, &ndc_y);
                         Set(ndc_x, ndc_y, ndc_z);
                     }
                     x++;
@@ -231,7 +236,7 @@ void Line::createPoints()
 
                     for (int j = 0; j < m_line_width; j++)
                     {
-                        this->convertToNDC(x, y + j, &ndc_x, &ndc_y);
+                        this->convertToNDC(x, y + j - pivot_point, &ndc_x, &ndc_y);
                         Set(ndc_x, ndc_y, ndc_z);
                     }
                     x++;
@@ -264,7 +269,7 @@ void Line::createPoints()
 
                     for (int j = 0; j < m_line_width; j++)
                     {
-                        this->convertToNDC(x, y + j, &ndc_x, &ndc_y);
+                        this->convertToNDC(x, y + j - pivot_point, &ndc_x, &ndc_y);
                         Set(ndc_x, ndc_y, ndc_z);
                     }
                     x--;
@@ -294,7 +299,7 @@ void Line::createPoints()
 
                     for (int j = 0; j < m_line_width; j++)
                     {
-                        this->convertToNDC(x, y + j, &ndc_x, &ndc_y);
+                        this->convertToNDC(x, y + j-pivot_point, &ndc_x, &ndc_y);
                         Set(ndc_x, ndc_y, ndc_z);
                     }
                     x--;
@@ -342,7 +347,7 @@ void Line::createPoints()
 
                         for (int j = 0; j < m_line_width; j++)
                         {
-                            this->convertToNDC(x, y + j, &ndc_x, &ndc_y);
+                            this->convertToNDC(x, y + j-pivot_point, &ndc_x, &ndc_y);
                             Set(ndc_x, ndc_y, ndc_z);
                         }
                         x++;
@@ -391,7 +396,7 @@ void Line::createPoints()
 
                         for (int j = 0; j < m_line_width; j++)
                         {
-                            this->convertToNDC(x, y + j, &ndc_x, &ndc_y);
+                            this->convertToNDC(x, y + j-pivot_point, &ndc_x, &ndc_y);
                             Set(ndc_x, ndc_y, ndc_z);
                         }
                         x++;
@@ -440,7 +445,7 @@ void Line::createPoints()
 
                         for (int j = 0; j < m_line_width; j++)
                         {
-                            this->convertToNDC(x, y + j, &ndc_x, &ndc_y);
+                            this->convertToNDC(x, y + j - pivot_point, &ndc_x, &ndc_y);
                             Set(ndc_x, ndc_y, ndc_z);
                         }
                         x--;
@@ -486,7 +491,7 @@ void Line::createPoints()
 
                         for (int j = 0; j < m_line_width; j++)
                         {
-                            this->convertToNDC(x, y + j, &ndc_x, &ndc_y);
+                            this->convertToNDC(x, y + j - pivot_point, &ndc_x, &ndc_y);
                             Set(ndc_x, ndc_y, ndc_z);
                         }
                         x--;
@@ -539,7 +544,7 @@ void Line::createPoints()
 
                         for (int j = 0; j < m_line_width; j++)
                         {
-                            this->convertToNDC(x + j, y, &ndc_x, &ndc_y);
+                            this->convertToNDC(x + j - pivot_point, y, &ndc_x, &ndc_y);
                             Set(ndc_x, ndc_y, ndc_z);
                         }
                         y++;
@@ -584,7 +589,7 @@ void Line::createPoints()
 
                         for (int j = 0; j < m_line_width; j++)
                         {
-                            this->convertToNDC(x + j, y, &ndc_x, &ndc_y);
+                            this->convertToNDC(x + j - pivot_point, y, &ndc_x, &ndc_y);
                             Set(ndc_x, ndc_y, ndc_z);
                         }
                         y--;
@@ -633,7 +638,7 @@ void Line::createPoints()
 
                         for (int j = 0; j < m_line_width; j++)
                         {
-                            this->convertToNDC(x + j, y, &ndc_x, &ndc_y);
+                            this->convertToNDC(x + j - pivot_point, y, &ndc_x, &ndc_y);
                             Set(ndc_x, ndc_y, ndc_z);
                         }
                         y++;
@@ -678,7 +683,7 @@ void Line::createPoints()
 
                         for (int j = 0; j < m_line_width; j++)
                         {
-                            this->convertToNDC(x + j, y, &ndc_x, &ndc_y);
+                            this->convertToNDC(x + j - pivot_point, y, &ndc_x, &ndc_y);
                             Set(ndc_x, ndc_y, ndc_z);
                         }
                         y--;


### PR DESCRIPTION
### Updates
- Dotted line now drawn according to line width
- Line with width higher than one now drawn with middle point as the pivot (figure 1) instead of the bottom left (figure 2)*

**Figure 1:**
![test](https://user-images.githubusercontent.com/11814787/107846066-55ed9680-6e13-11eb-884a-91cb19c6b17a.png)

**Figure 2:**
![test_old](https://user-images.githubusercontent.com/11814787/107846072-5a19b400-6e13-11eb-961d-430d1e52e70a.png)

*My aim was to make it so that if line with width higher than one, the end points will be drawn diagonally (figure 3). This turned out to be more intricate than it seems and we might not have the time to implement this feature on time.
**Figure 3 (example image):**
![line_aim](https://user-images.githubusercontent.com/11814787/107846146-0b204e80-6e14-11eb-92a0-37daa148e7b5.png)

